### PR TITLE
Add all items counter on the Homepage 

### DIFF
--- a/src/modules/mealCounter.js
+++ b/src/modules/mealCounter.js
@@ -1,10 +1,11 @@
+// Display meal counter function
 const mealcounter = async () => {
   const request = new Request('https://www.themealdb.com/api/json/v1/1/filter.php?a=American');
   const result = await fetch(request);
   const data = await result.json();
   return data.meals.length;
 };
-
+// Display show count function
 const showCount = (num) => {
   const homeli = document.querySelector('.home-li');
   homeli.textContent = `(${num})Meals`;


### PR DESCRIPTION
# In this milestone:

- The correct number is displayed on the Homepage.

- Respected the following rules:

  - The homepage Items counter is implemented as a separate module.
  - I made the counting based on what is actually displayed on the page.
